### PR TITLE
Revert "gralloc: Fix integer overflow in roundUpToPageSize"

### DIFF
--- a/gralloc/gralloc_priv.h
+++ b/gralloc/gralloc_priv.h
@@ -73,7 +73,7 @@
 #define USE_SYSTEM_HEAP_FOR_SENSORS          GRALLOC_PROP("use_system_heap_for_sensors")
 
 #define ROUND_UP_PAGESIZE(x) roundUpToPageSize(x)
-inline size_t roundUpToPageSize(size_t x) {
+inline int roundUpToPageSize(int x) {
   return (x + (getpagesize() - 1)) & ~(getpagesize() - 1);
 }
 


### PR DESCRIPTION
This reverts commit dbf678a61552ae94e104177853f32309eb9b5088.